### PR TITLE
Force IPv4 connection in test_gzip to avoid IPv6 problems

### DIFF
--- a/jaraco/stream/test_gzip.py
+++ b/jaraco/stream/test_gzip.py
@@ -36,7 +36,7 @@ def gzip_server(gzipped_json):
     port = 8080
     addr = host, port
     httpd = http.server.HTTPServer(addr, MyHandler)
-    url = 'http://localhost:{port}/'.format(**locals())
+    url = 'http://127.0.0.1:{port}/'.format(**locals())
     try:
         threading.Thread(target=httpd.serve_forever).start()
         yield url


### PR DESCRIPTION
Force test_gzip to connect to 127.0.0.1 rather than the generic
'localhost' address.  This fixes test failures when localhost resolves
to an IPv6 address first, since the test server does not support IPv6
at all.

Fixes #3.