### PR TITLE
Fallback to windows-1252 if specified decoding fails.

### DIFF
--- a/jaraco/stream/buffer.py
+++ b/jaraco/stream/buffer.py
@@ -98,9 +98,12 @@ class DecodingLineBuffer(LineBuffer):
     def lines(self):
         for line in super(DecodingLineBuffer, self).lines():
             try:
-                yield line.decode(self.encoding, self.errors)
+                yield line.decode(self.encoding, 'strict')
             except UnicodeDecodeError:
-                self.handle_exception()
+                try:
+                    yield line.decode('windows-1252', self.errors)
+                except UnicodeDecodeError:
+                    self.handle_exception()
 
     def handle_exception(self):
         msg = textwrap.dedent(


### PR DESCRIPTION
Attempt to decode with windows-1252 if specified (default is utf-8) strict decoding raises `UnicodeDecodeError`.

The `irc` Python library relies on this one. A common issue in IRC chats is the use of different encodings. The utf-8 is the most common, but Windows users with certain mIRC scripts have windows-1252 by default and leave it unchanged. It is desirable to try different encodings to properly read everyone.

The change opens the possibility to handle several encodings following a preference order (although hardcoded). The logic is introduced, but more changes to the code would be needed. It still allows control over how decoding errors are handled in the last attempted encoding.

If somehow this does not follow your coding guidelines, feel free to just reject the pull request. It could result in more people adding more encodings by nested `try` and `except UnicodeDecodeError`.